### PR TITLE
fix modal event liseners

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -21,7 +21,7 @@
   <body>
     <include src="./partials/header-home-page.html"></include>
     <main>
-      <button
+      <!-- <button
         style="width: 100px; height: 50px; margin-left: 50%"
         id="btn-addToWatch"
       >
@@ -29,7 +29,7 @@
       </button>
       <button style="width: 100px; height: 50px" id="btn-addToQueue">
         Add to queue
-      </button>
+      </button> -->
       <include src="./partials/search-by-genres.html"></include>
       <include src="./partials/movies-list.html"></include>
       <include src="./partials/pagination.html"></include>

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,6 @@ import { renderLoadingSpinner } from './js/loadingSpinner';
 import { addToList } from './js/addToList';
 import { openModal, closeModal } from './js/details';
 
-
 // VARIABLES
 const searchForm = document.getElementById('search-form');
 export const moviesContainer = document.querySelector('.covers-container');
@@ -95,15 +94,3 @@ moviesContainer.addEventListener('click', openModal);
 
 // Close modal
 closeBtn.addEventListener('click', closeModal);
-
-window.addEventListener('keydown', (event) => {
-  if (event.key === 'Escape') {
-    closeModal();
-  }
-});
-
-modal.addEventListener('click', (event) => {
-  if (event.target === modal) {
-    closeModal();
-  }
-});

--- a/src/js/details.js
+++ b/src/js/details.js
@@ -23,6 +23,8 @@ const openModal = async (ev) => {
     if (movieData) {
       populateModalContent(movieData);
       modal.style.display = 'block';
+      window.addEventListener('keydown', handleEscapeKey);
+      window.addEventListener('click', handleClickOutsideModal);
     }
   }
 };
@@ -64,6 +66,22 @@ const getGenreNames = (genres) => {
 // Close modal
 const closeModal = () => {
   modal.style.display = 'none';
+  window.removeEventListener('keydown', closeModal);
+  modal.removeEventListener('click', closeModal);
+};
+
+// Listener for Escape
+const handleEscapeKey = (ev) => {
+  if (ev.key === 'Escape') {
+    closeModal();
+  }
+};
+
+// Listener for click outside modal
+const handleClickOutsideModal = (ev) => {
+  if (ev.target === modal) {
+    closeModal();
+  }
 };
 
 export { modal, openModal, closeModal };

--- a/src/partials/details.html
+++ b/src/partials/details.html
@@ -29,11 +29,13 @@
         <p id="movieAbout" class="details__about-content"></p>
       </div>
       <div class="details__btn-wrapper">
-        <button type="button" class="details__btn">
+        <button type="button" id="btn-addToWatch" class="details__btn">
           add to<br />
           Watched
         </button>
-        <button type="button" class="details__btn">add to queue</button>
+        <button type="button" id="btn-addToQueue" class="details__btn">
+          add to queue
+        </button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Lisenery z escape i kliknieciu poza modal usuwają się wraz z zamknięciem modala.
Zmieniłem ID przycisków w modalu na odpowiadające tym z addToList.js