### PR TITLE
Cookies and trailer btn visual fix

### DIFF
--- a/src/partials/details.html
+++ b/src/partials/details.html
@@ -3,7 +3,16 @@
     <button id="close-modal" type="button" class="details__close">
       &times;
     </button>
-    <div id="movieCover" class="details__cover"></div>
+    <div class="details__cover-wrapper">
+      <div id="movieCover" class="details__cover"></div>
+      <button
+        type="button"
+        id="btn-trailer"
+        class="details__btn details__btn--trailer"
+      >
+        Watch trailer
+      </button>
+    </div>
     <div class="details__content">
       <h2 id="movieTitle" class="details__title"></h2>
       <table>
@@ -41,13 +50,6 @@
           </button>
         </div>
       </div>
-      <button
-        type="button"
-        id="btn-trailer"
-        class="details__btn details__btn--trailer"
-      >
-        Watch trailer
-      </button>
     </div>
   </div>
 </div>

--- a/src/sass/partials/_cookies.scss
+++ b/src/sass/partials/_cookies.scss
@@ -26,6 +26,9 @@
   }
 
   &__info-wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
     max-width: 300px;
     margin: 0 auto;
     padding: 10px;

--- a/src/sass/partials/_details.scss
+++ b/src/sass/partials/_details.scss
@@ -48,6 +48,12 @@
       min-width: 375px;
     }
   }
+  &__cover-wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    align-items: center;
+  }
   &__title {
     font-size: 20px;
     line-height: 1.15;
@@ -142,12 +148,9 @@
       transform: scale(1);
     }
     &--trailer {
-      width: 240px;
-      @media screen and (min-width: $breakpointTablet) {
-        width: 265px;
-      }
+      width: 100%;
       @media screen and (min-width: $breakpointDesktop) {
-        width: 280px;
+        width: 95%;
       }
     }
   }


### PR DESCRIPTION
Wizualna poprawka cookies.
Przycisk watch trailer przeniesiony pod cover. W modalu był na samym dole, co było trochę dziwne.